### PR TITLE
remove unnecessary dependency

### DIFF
--- a/src/exercises-final/03-extra.2.js
+++ b/src/exercises-final/03-extra.2.js
@@ -15,7 +15,7 @@ function useLocalStorageState({
   const serializedState = serialize(state)
   React.useEffect(() => {
     window.localStorage.setItem(key, serializedState)
-  }, [key, serialize, serializedState])
+  }, [key, serializedState])
 
   return [state, setState]
 }


### PR DESCRIPTION
Because the value is already serialized, there is no need for serialize to be part of the dependency array (the state value already reflects the serialized value).