### PR TITLE
change 'input array' to 'dependency array'

### DIFF
--- a/src/exercises/03.md
+++ b/src/exercises/03.md
@@ -45,10 +45,7 @@ gets re-rendered).
 
 Really, we _only_ want localStorage to get updated when the `count` state
 actually changes. It doesn't need to re-run any other time. Luckily for us,
-`React.useEffect` allows you to pass a second argument called the "inputs array"
+`React.useEffect` allows you to pass a second argument called the "dependency array"
 which signals to React that your effect callback function should be called when
-(and only when) those inputs change. So we can use this to avoid doing
+(and only when) those dependencies change. So we can use this to avoid doing
 unnecessary work!
-
-NOTE: even though it's called the "inputs array," react does not actually pass
-those values as inputs to your effect callback. It's more conceptual.


### PR DESCRIPTION
Motivation:

- the [react docs](https://reactjs.org/docs/hooks-reference.html#useeffect) don't seem to call this an "inputs array", but refer to the concept as "dependencies list".

- the [`03.js` exercise itself](https://github.com/kentcdodds/learn-react-hooks/blob/28a9ce43c13d72eada682fe8204c987e5a83d5c0/src/exercises/03.js#L22) refers to the docs for information about "dependency array" but the `03.md` file did not refer to this concept by the same name.